### PR TITLE
Fix adding defaultCssClass

### DIFF
--- a/src/Selectoo.php
+++ b/src/Selectoo.php
@@ -410,7 +410,7 @@ class Selectoo extends BaseControl
 			$element->multiple(true);
 		}
 		if ($this->getDefaultCssClass() !== null) {
-			$element->class(($element->class ? $element->class . ' ' : '') . $this->getDefaultCssClass());
+			$element->addClass($this->getDefaultCssClass());
 		}
 		return $element;
 	}


### PR DESCRIPTION
Because method class() is not used for css. 
For work with attributes are there magic methods add<attributeName>, get<attributeName> and set<attributeName>. 
In this case addClass('class') is better solution, because your solution could make array string conversion problem in some case.

I don`t make pull request offten. Sorry, if there is some mistakes in usage.

David